### PR TITLE
fix: await result before printing retry stats

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -5,4 +5,3 @@ isort==5.10.1
 black==22.3.0
 flake8==4.0.1
 pydocstyle==6.1.1
-openai==0.26.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-steamship===2.3.13
+steamship===2.13.18
 tenacity==8.2.0

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,1 @@
-"""NLPCloud Tagger."""
+"""OpenAI Embedder."""

--- a/src/api.py
+++ b/src/api.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Type
 
 from pydantic import Field
 from steamship import Tag
-from steamship.invocable import Config, Invocable, create_handler
+from steamship.invocable import Config, Invocable
 from steamship.plugin.request import PluginRequest
 
 from openai.api_spec import validate_model
@@ -55,6 +55,3 @@ class OpenAIEmbedderPlugin(SpanTagger, Invocable):
             return tags
         else:
             return []
-
-
-handler = create_handler(OpenAIEmbedderPlugin)

--- a/src/openai/__init__.py
+++ b/src/openai/__init__.py
@@ -1,1 +1,1 @@
-"""Collection of utility functions and classes to interface with NLPCloud."""
+"""Collection of utility functions and classes to interface with OpenAI."""

--- a/src/openai/request_utils.py
+++ b/src/openai/request_utils.py
@@ -42,9 +42,9 @@ async def _json_post(session: aiohttp.ClientSession, url: str, body: Dict, servi
                 )
             return output
 
-    result = _inner_json_post()
+    result = await _inner_json_post()
     logging.info("Retry statistics: " + json.dumps(_inner_json_post.retry.statistics))
-    return await result
+    return result
 
 
 

--- a/steamship.json
+++ b/steamship.json
@@ -1,7 +1,7 @@
 {
 	"type": "plugin",
 	"handle": "openai-embedder",
-	"version": "0.0.15",
+	"version": "0.0.17",
 	"description": "Embed text with OpenAI.",
 	"author": "steamship",
 	"entrypoint": "Unused",


### PR DESCRIPTION
Logging the retry statistics *before* the operation has executed leaves empty results (`{}`). With this change, we should see log entries that look more like: `{"start_time": 0.167486875, "attempt_number": 2, "idle_for": 2.0836665377294263, "delay_since_first_attempt": 1.3000000000013001e-05}` 

Once merged, we can `ship it` for a new version of the plugin (i assume with `steamshipProd`?)